### PR TITLE
Added Code to Encoder Knob to Emulate Enter Button

### DIFF
--- a/code/JCPM.ino
+++ b/code/JCPM.ino
@@ -259,6 +259,11 @@ void volume(){
         Consumer.write(MEDIA_PREVIOUS);
         delay(50);
       }
+  if (SW1 == 0) { //Emulate keyboard enter button when encoder knob is pressed down:
+      Keyboard.press(KEY_ENTER);
+      Keyboard.release(KEY_ENTER);
+      delay(50);
+    }
   if ((SW7 == 0) && (underLight == 0)) {        
     underLight = 1;
     for(int i=8; i<12; i++){


### PR DESCRIPTION
I found that the encoder knob will turn up and down volume when turned, but doesn't do anything when pressed. 
This code change enables the encoder knob button press to emulate a keyboard's `Enter` button.

**Future Idea**
In future builds, I could code this button to mute/unmute master volume.